### PR TITLE
bugfix/changed the method for handling resource paths by replacing instead of slice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.2 (2024-09-25)
+
+### Bugfixes
+
+- Changed the method for handling resource paths by replacing the base URL directly instead of slicing it. This resolves errors that occurred, e.g., when using `https` base URLs.
+
 ## 1.0.1 (2024-09-13)
 
 ### Features

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ export default function sri(options: SriOptions = {}): Plugin {
         [...scripts, ...styles].map(async (node) => {
           let source: BinaryLike = '';
           const attribute = ((node.attrs?.src && 'src') || (node.attrs?.href && 'href'))!;
-          const resourceUrl = node.getAttribute(attribute)!;
+          const resourceUrl = node.getAttribute(attribute)!.replace(BASE_URL, '');
 
           // load external resource
           if (external && resourceUrl.startsWith('http')) {
@@ -65,8 +65,7 @@ export default function sri(options: SriOptions = {}): Plugin {
 
           // load local resource
           if (!resourceUrl.startsWith('http')) {
-            const resourceWithoutBaseUrl = resourceUrl.slice(BASE_URL.length);
-            const bundleItem = bundle![resourceWithoutBaseUrl];
+            const bundleItem = bundle![resourceUrl];
 
             if ('code' in bundleItem) {
               source = bundleItem.code;


### PR DESCRIPTION
bugfix: Changed the method for handling resource paths by replacing the base URL directly instead of slicing it. This resolves errors that occurred, e.g., when using https base URLs